### PR TITLE
Remove unused parameter in json_formatter.cpp

### DIFF
--- a/src/text/json_formatter.cpp
+++ b/src/text/json_formatter.cpp
@@ -35,7 +35,7 @@ namespace //anonymous
     class json_fmt_visitor : public const_nbt_visitor
     {
     public:
-        json_fmt_visitor(std::ostream& os, const json_formatter& fmt):
+        json_fmt_visitor(std::ostream& os):
             os(os)
         {}
 
@@ -199,7 +199,7 @@ namespace //anonymous
 
 void json_formatter::print(std::ostream& os, const tag& t) const
 {
-    json_fmt_visitor v(os, *this);
+    json_fmt_visitor v(os);
     t.accept(v);
 }
 


### PR DESCRIPTION
Benefit: it's a step towards enabling more warning flags and treating more of them as errors, which would increase code quality. This one fixes the `-Wunused-parameter` error